### PR TITLE
Hooks into all gamemodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ If the fly mode should be disabled when a player disconnect.
 **/is fly** - This command toggles flight **On** and **Off** 
 
 ## Permissions
-**[gamemode].island.fly** - **/is fly** 
+**[gamemode].island.fly** - For usage of flight command
 
 Example: 
     **bskyblock.island.fly**
 
-**[gamemode].island.flybypass** - **Enables user to use fly command on other islands too**
+**[gamemode].island.flybypass** - Enables user to use fly command on other islands too
 
 
 Example:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # IslandFly
 
-Add-on for BentoBox to allow players of BSkyBlock or AcidIsland to fly on their island. This add-on will work for both game modes.
+Add-on for BentoBox to allow players of Gamemode Addons to fly on their island.
 
 ## How to use
 
-1. Place the jar in the addons folder of the BentoBox plugin
+1. Place the .jar in the addons folder of the BentoBox plugin
 2. Restart the server
 3. The addon will create a data folder and inside the folder will be a config.yml
-4. Edit the config.yml how you want
+4. Edit the config.yml if required
 5. Restart the server if you make a change
 
 ## Config.yml
@@ -21,6 +21,20 @@ How many seconds the addon will wait before disabling fly mode when a player exi
 If the fly mode should be disabled when a player disconnect.
 
 ## Commands
+**/is fly** - This command toggles flight **On** and **Off** 
 
-/is fly (bskyblock.fly)
-Toggle fly mode of the sender.
+## Permissions
+**[gamemode].island.fly** - **/is fly** 
+
+Example: 
+    **bskyblock.island.fly**
+
+**[gamemode].island.flybypass** - **Enables user to use fly command on other islands too**
+
+
+Example:
+**caveblock.island.flybypass**
+  
+
+
+

--- a/src/main/java/world/bentobox/islandfly/FlySettings.java
+++ b/src/main/java/world/bentobox/islandfly/FlySettings.java
@@ -5,7 +5,8 @@ public class FlySettings {
     private int flyTimeout;
     private boolean flyDisabledOnLogout;
 
-    public FlySettings(final IslandFlyAddon addon){
+    public FlySettings(final IslandFlyAddon addon) {
+        
         // Load configuration file
         addon.saveDefaultConfig();
         // Load datas from config

--- a/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
+++ b/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
@@ -38,14 +38,15 @@ public class FlyToggleCommand extends CompositeCommand {
         islands.userIsOnIsland(user.getWorld(), user);
         final Optional<Island> island = islands.getIslandAt(user.getLocation());
         
-        if(!user.hasPermission(this.getPermissionPrefix() + "island.flybypass") && (!island.isPresent() || !island.get().getMembers().containsKey(user.getUniqueId()))){
+        if (!user.hasPermission(this.getPermissionPrefix() + "island.flybypass") && (!island.isPresent() || !island.get().getMembers().containsKey(user.getUniqueId()))) {
             
         	user.sendMessage("islandfly.command.only-on-island");
             return true;
         }
         
         final Player player = user.getPlayer();
-        if(user.getPlayer().getAllowFlight()){
+	
+        if (user.getPlayer().getAllowFlight()) {
         	
             // Disable fly and notify player
             player.setFlying(false);

--- a/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
+++ b/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
@@ -28,9 +28,9 @@ public class FlyToggleCommand extends CompositeCommand {
     public boolean execute(User user, String label, List<String> args) {
         
     	// Checks world from corresponding gamemode command with the world player is executing in
-    	if(this.getWorld() != Util.getWorld(user.getWorld())){
-    	user.sendMessage("islandfly.wrong-world");
-    	return true;
+    	if (this.getWorld() != Util.getWorld(user.getWorld())) {
+    	    user.sendMessage("islandfly.wrong-world");
+    	    return true;
     	}
     	
     	// Allow this command only on island
@@ -39,8 +39,7 @@ public class FlyToggleCommand extends CompositeCommand {
         final Optional<Island> island = islands.getIslandAt(user.getLocation());
         
         if (!user.hasPermission(this.getPermissionPrefix() + "island.flybypass") && (!island.isPresent() || !island.get().getMembers().containsKey(user.getUniqueId()))) {
-            
-        	user.sendMessage("islandfly.command.only-on-island");
+            user.sendMessage("islandfly.command.only-on-island");
             return true;
         }
         

--- a/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
+++ b/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
@@ -5,40 +5,54 @@ import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.IslandsManager;
+import world.bentobox.bentobox.util.Util;
 
 import java.util.List;
 import java.util.Optional;
 
 public class FlyToggleCommand extends CompositeCommand {
 
-    public FlyToggleCommand(final CompositeCommand baseCmd) {
-        super(baseCmd, "fly");
+	
+    public FlyToggleCommand(CompositeCommand parent) {
+        super(parent, "fly");
     }
 
     @Override
     public void setup() {
-        this.setPermission("fly");
+        this.setPermission("island.fly");
         this.setOnlyPlayer(true);
         this.setDescription("islandfly.command.description");
     }
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        // Allow this command only on island
+        
+    	// Checks world from corresponding gamemode command with the world player is executing in
+    	if(this.getWorld() != Util.getWorld(user.getWorld())){
+    	user.sendMessage("islandfly.wrong-world");
+    	return true;
+    	}
+    	
+    	// Allow this command only on island
         final IslandsManager islands = this.getIslands();
         islands.userIsOnIsland(user.getWorld(), user);
         final Optional<Island> island = islands.getIslandAt(user.getLocation());
-        if(!user.hasPermission("islandfly.bypass") && (!island.isPresent() || !island.get().getMembers().containsKey(user.getUniqueId()))){
-            user.sendMessage("islandfly.command.only-on-island");
+        
+        if(!user.hasPermission(this.getPermissionPrefix() + "island.flybypass") && (!island.isPresent() || !island.get().getMembers().containsKey(user.getUniqueId()))){
+            
+        	user.sendMessage("islandfly.command.only-on-island");
             return true;
         }
+        
         final Player player = user.getPlayer();
         if(user.getPlayer().getAllowFlight()){
+        	
             // Disable fly and notify player
             player.setFlying(false);
             player.setAllowFlight(false);
             user.sendMessage("islandfly.disable-fly");
-        }else{
+        } else {
+        	
             // Enable fly and notify player
             player.setAllowFlight(true);
             user.sendMessage("islandfly.enable-fly");

--- a/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
+++ b/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
@@ -21,7 +21,7 @@ public class IslandFlyAddon extends Addon {
           
         //Hook into gamemodes
         this.getPlugin().getAddonsManager().getGameModeAddons().forEach(gm -> {
-            if(gm.getPlayerCommand().isPresent()) {
+            if (gm.getPlayerCommand().isPresent()) {
         	    new FlyToggleCommand(gm.getPlayerCommand().get());
         	    hooked=true;
         	}

--- a/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
+++ b/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
@@ -28,15 +28,15 @@ public class IslandFlyAddon extends Addon {
         	
         });
         
-        if(hooked) 
-        {	
+        if (hooked) {	
+            
             // Register Listeners
             final PluginManager pluginManager = Bukkit.getPluginManager();
             pluginManager.registerEvents(new FlyListener(this), this.getPlugin());
             pluginManager.registerEvents(new FlyDeathListener(this), this.getPlugin());
             
             // Register listener to disable fly on logout if activated
-            if(settings.isFlyDisabledOnLogout()) {
+            if (settings.isFlyDisabledOnLogout()) {
                 pluginManager.registerEvents(new FlyLogoutListener(), this.getPlugin());
             }
         }

--- a/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
+++ b/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
@@ -21,17 +21,16 @@ public class IslandFlyAddon extends Addon {
           
         //Hook into gamemodes
         this.getPlugin().getAddonsManager().getGameModeAddons().forEach(gm -> {
-        	if(gm.getPlayerCommand().isPresent()) 
-        	{
-        		new FlyToggleCommand(gm.getPlayerCommand().get());
-        		hooked=true;
+            if(gm.getPlayerCommand().isPresent()) {
+        	    new FlyToggleCommand(gm.getPlayerCommand().get());
+        	    hooked=true;
         	}
         	
         });
         
         if(hooked) 
         {	
-        	// Register Listeners
+            // Register Listeners
             final PluginManager pluginManager = Bukkit.getPluginManager();
             pluginManager.registerEvents(new FlyListener(this), this.getPlugin());
             pluginManager.registerEvents(new FlyDeathListener(this), this.getPlugin());
@@ -46,7 +45,7 @@ public class IslandFlyAddon extends Addon {
     
     @Override
     public void onDisable() {
-    	//Nothing to do here
+        //Nothing to do here
     }
 
     

--- a/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
+++ b/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
@@ -3,46 +3,53 @@ package world.bentobox.islandfly;
 import world.bentobox.islandfly.listeners.FlyDeathListener;
 import world.bentobox.islandfly.listeners.FlyListener;
 import world.bentobox.islandfly.listeners.FlyLogoutListener;
+
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.Addon;
-import world.bentobox.bentobox.api.commands.CompositeCommand;
 
 public class IslandFlyAddon extends Addon {
 
     private FlySettings settings;
-
+    private boolean hooked=false;
+    
+    
     @Override
     public void onEnable() {
         // Load configuration
         this.settings = new FlySettings(this);
-        // Register Listeners
-        final PluginManager pluginManager = Bukkit.getPluginManager();
-        pluginManager.registerEvents(new FlyListener(this), this.getPlugin());
-        pluginManager.registerEvents(new FlyDeathListener(this), this.getPlugin());
-        // Register listener to disable fly on logout if activated
-        if(settings.isFlyDisabledOnLogout())
-            pluginManager.registerEvents(new FlyLogoutListener(), this.getPlugin());
-        // BSkyBlock hook in
-        this.getPlugin().getAddonsManager().getAddonByName("BSkyBlock").ifPresent(bskyblock -> {
-            final CompositeCommand bsbIslandCmd = BentoBox.getInstance().getCommandsManager().getCommand("island");
-            if (bsbIslandCmd != null) {
-                new FlyToggleCommand(bsbIslandCmd);
-            }
+          
+        //Hook into gamemodes
+        this.getPlugin().getAddonsManager().getGameModeAddons().forEach(gm -> {
+        	if(gm.getPlayerCommand().isPresent()) 
+        	{
+        		new FlyToggleCommand(gm.getPlayerCommand().get());
+        		hooked=true;
+        	}
+        	
         });
-        // AcidIsland hook in
-        this.getPlugin().getAddonsManager().getAddonByName("AcidIsland").ifPresent(acidIsland -> {
-            final CompositeCommand acidIslandCmd = getPlugin().getCommandsManager().getCommand("ai");
-            if (acidIslandCmd != null) {
-                new FlyToggleCommand(acidIslandCmd);
+        
+        if(hooked) 
+        {	
+        	// Register Listeners
+            final PluginManager pluginManager = Bukkit.getPluginManager();
+            pluginManager.registerEvents(new FlyListener(this), this.getPlugin());
+            pluginManager.registerEvents(new FlyDeathListener(this), this.getPlugin());
+            
+            // Register listener to disable fly on logout if activated
+            if(settings.isFlyDisabledOnLogout()) {
+                pluginManager.registerEvents(new FlyLogoutListener(), this.getPlugin());
             }
-        });
+        }
     }
 
+    
     @Override
-    public void onDisable() {}
+    public void onDisable() {
+    	//Nothing to do here
+    }
 
+    
     /**
      * Get addon settings
      * @return settings

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
@@ -28,7 +28,7 @@ public class FlyDeathListener implements Listener {
 		final Player player = event.getEntity();
 		final UUID playerUUID = player.getUniqueId();
 		final User user = User.getInstance(playerUUID);
-		if(user.hasPermission(plugin.getIWM().getPermissionPrefix(user.getWorld()) + "island.flybypass")) return;
+		if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
 		disableFly(user);
 	}
 	

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
@@ -24,31 +24,37 @@ public class FlyDeathListener implements Listener {
 
 	@EventHandler
 	public void onDeath(final PlayerDeathEvent event) {
-		//Disable fly on death anyway
-		final Player player = event.getEntity();
-		final UUID playerUUID = player.getUniqueId();
-		final User user = User.getInstance(playerUUID);
-		if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
-		disableFly(user);
+		
+	    //Disable fly on death anyway
+	    final Player player = event.getEntity();
+	    final UUID playerUUID = player.getUniqueId();
+	    final User user = User.getInstance(playerUUID);
+		
+	    if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
+	    disableFly(user);
 	}
 	
 	@EventHandler
 	public void onRespawn(PlayerRespawnEvent event) {
-		//If a player respawns on an island that he's added to, do nothing. 
-		//Otherwise - disable Fly
-		final Player player = event.getPlayer();
-		final UUID playerUUID = player.getUniqueId();
-		Optional<Island> island = plugin.getIslands().getIslandAt(player.getLocation());
-		if(island.isPresent())
-		if(island.get().getMembers().containsKey(playerUUID)) {
-			//Enable only if it was previously enabled too
-			if(player.getAllowFlight())
-			player.setFlying(true);
-		}
+		
+	    //If a player respawns on an island that he's added to, do nothing. 
+	    //Otherwise - disable Fly
+	    final Player player = event.getPlayer();
+	    final UUID playerUUID = player.getUniqueId();
+	    Optional<Island> island = plugin.getIslands().getIslandAt(player.getLocation());
+		
+	    if(island.isPresent())
+	    if(island.get().getMembers().containsKey(playerUUID)) {
+		    
+	        //Enable only if it was previously enabled too
+	        if(player.getAllowFlight())
+	        player.setFlying(true);
+	    }
 	}
 	
 	
-	private void disableFly(final User user){
+	private void disableFly(final User user) {
+		
 		final Player player = user.getPlayer();
 		player.setFlying(false);
     }

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
@@ -30,7 +30,7 @@ public class FlyDeathListener implements Listener {
 	    final UUID playerUUID = player.getUniqueId();
 	    final User user = User.getInstance(playerUUID);
 		
-	    if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
+	    if (user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
 	    disableFly(user);
 	}
 	
@@ -43,11 +43,11 @@ public class FlyDeathListener implements Listener {
 	    final UUID playerUUID = player.getUniqueId();
 	    Optional<Island> island = plugin.getIslands().getIslandAt(player.getLocation());
 		
-	    if(island.isPresent())
-	    if(island.get().getMembers().containsKey(playerUUID)) {
+	    if (island.isPresent())
+	    if (island.get().getMembers().containsKey(playerUUID)) {
 		    
 	        //Enable only if it was previously enabled too
-	        if(player.getAllowFlight())
+	        if (player.getAllowFlight())
 	        player.setFlying(true);
 	    }
 	}

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyDeathListener.java
@@ -28,7 +28,7 @@ public class FlyDeathListener implements Listener {
 		final Player player = event.getEntity();
 		final UUID playerUUID = player.getUniqueId();
 		final User user = User.getInstance(playerUUID);
-		if(user.hasPermission("islandfly.bypass")) return;
+		if(user.hasPermission(plugin.getIWM().getPermissionPrefix(user.getWorld()) + "island.flybypass")) return;
 		disableFly(user);
 	}
 	

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
@@ -19,40 +19,49 @@ public class FlyListener implements Listener {
     private final FlySettings settings;
     private final BentoBox plugin;
 
-    public FlyListener(final IslandFlyAddon addon){
+    public FlyListener(final IslandFlyAddon addon) {
+        
         this.settings = addon.getSettings();
         this.plugin = addon.getPlugin();
     }
 
     @EventHandler(ignoreCancelled = true)
-    public void onExitIsland(final IslandEvent.IslandExitEvent event){
+    public void onExitIsland(final IslandEvent.IslandExitEvent event) {
+        
         // Check only when player exit is own island
         final UUID playerUUID = event.getPlayerUUID();
+        
         if(!event.getIsland().getMembers().containsKey(playerUUID)) return;
 
         // Player already flying
         final User user = User.getInstance(playerUUID);
         
         if(!user.getPlayer().getAllowFlight()) return;
+        
         // Bypass permission
         if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
 
         // Alert player fly will be disabled
         final int flyTimeout = settings.getFlyTimeout();
         user.sendMessage("islandfly.fly-outside-alert", TextVariables.NUMBER, String.valueOf(flyTimeout));
+        
         // If timeout is 0 or less disable fly immediately
-        if(flyTimeout <= 0){
+        if(flyTimeout <= 0) {
             disableFly(user);
             return;
         }
+        
         // Else disable fly with a delay
-        this.plugin.getServer().getScheduler().runTaskLater(plugin, ()->{
+        this.plugin.getServer().getScheduler().runTaskLater(plugin, ()-> {
+            
             // Verify player is still online
             if(!user.isOnline()) return;
+            
             final IslandsManager islands = plugin.getIslands();
+            
             // Check player is not on his own island
             if(!(islands.userIsOnIsland(user.getWorld(), user)
-            && islands.getIslandAt(user.getLocation()).get().getMembers().containsKey(playerUUID))){
+            && islands.getIslandAt(user.getLocation()).get().getMembers().containsKey(playerUUID))) {
                 disableFly(user);
             }
             else {
@@ -65,8 +74,10 @@ public class FlyListener implements Listener {
      * Disable player fly and alert it
      * @param user
      */
-    private void disableFly(final User user){
+    private void disableFly(final User user) {
+        
         final Player player = user.getPlayer();
+        
         player.setFlying(false);
         player.setAllowFlight(false);
         user.sendMessage("islandfly.disable-fly");

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
@@ -3,7 +3,6 @@ package world.bentobox.islandfly.listeners;
 import world.bentobox.islandfly.FlySettings;
 import world.bentobox.islandfly.IslandFlyAddon;
 
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -36,7 +35,7 @@ public class FlyListener implements Listener {
         
         if(!user.getPlayer().getAllowFlight()) return;
         // Bypass permission
-        if(user.hasPermission(plugin.getIWM().getPermissionPrefix(user.getWorld()) + "island.flybypass")) return;
+        if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
 
         // Alert player fly will be disabled
         final int flyTimeout = settings.getFlyTimeout();

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
@@ -31,22 +31,22 @@ public class FlyListener implements Listener {
         // Check only when player exit is own island
         final UUID playerUUID = event.getPlayerUUID();
         
-        if(!event.getIsland().getMembers().containsKey(playerUUID)) return;
+        if (!event.getIsland().getMembers().containsKey(playerUUID)) return;
 
         // Player already flying
         final User user = User.getInstance(playerUUID);
         
-        if(!user.getPlayer().getAllowFlight()) return;
-        
+        if (!user.getPlayer().getAllowFlight()) return;
         // Bypass permission
-        if(user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
+        if (user.hasPermission(plugin.getIWM().getAddon(user.getWorld()).get().getPermissionPrefix() + "island.flybypass")) return;
 
         // Alert player fly will be disabled
         final int flyTimeout = settings.getFlyTimeout();
+        
         user.sendMessage("islandfly.fly-outside-alert", TextVariables.NUMBER, String.valueOf(flyTimeout));
         
         // If timeout is 0 or less disable fly immediately
-        if(flyTimeout <= 0) {
+        if (flyTimeout <= 0) {
             disableFly(user);
             return;
         }
@@ -60,7 +60,7 @@ public class FlyListener implements Listener {
             final IslandsManager islands = plugin.getIslands();
             
             // Check player is not on his own island
-            if(!(islands.userIsOnIsland(user.getWorld(), user)
+            if (!(islands.userIsOnIsland(user.getWorld(), user)
             && islands.getIslandAt(user.getLocation()).get().getMembers().containsKey(playerUUID))) {
                 disableFly(user);
             }

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyListener.java
@@ -2,6 +2,8 @@ package world.bentobox.islandfly.listeners;
 
 import world.bentobox.islandfly.FlySettings;
 import world.bentobox.islandfly.IslandFlyAddon;
+
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -31,9 +33,10 @@ public class FlyListener implements Listener {
 
         // Player already flying
         final User user = User.getInstance(playerUUID);
+        
         if(!user.getPlayer().getAllowFlight()) return;
         // Bypass permission
-        if(user.hasPermission("islandfly.bypass")) return;
+        if(user.hasPermission(plugin.getIWM().getPermissionPrefix(user.getWorld()) + "island.flybypass")) return;
 
         // Alert player fly will be disabled
         final int flyTimeout = settings.getFlyTimeout();

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyLogoutListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyLogoutListener.java
@@ -9,7 +9,7 @@ public class FlyLogoutListener implements Listener {
 
 	
     @EventHandler
-    public void onLogout(final PlayerQuitEvent event){
+    public void onLogout(final PlayerQuitEvent event) {
 
         final Player player = event.getPlayer();
 

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyLogoutListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyLogoutListener.java
@@ -7,13 +7,13 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 public class FlyLogoutListener implements Listener {
 
+	
     @EventHandler
     public void onLogout(final PlayerQuitEvent event){
 
         final Player player = event.getPlayer();
 
         if(!player.getAllowFlight()) return;
-        if(player.hasPermission("islandfly.bypass")) return;
 
         // Disable fly
         player.setFlying(false);

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyLogoutListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyLogoutListener.java
@@ -12,8 +12,9 @@ public class FlyLogoutListener implements Listener {
     public void onLogout(final PlayerQuitEvent event) {
 
         final Player player = event.getPlayer();
-
-        if(!player.getAllowFlight()) return;
+	
+	//Stop further execution if fly wasn't toggled
+        if (!player.getAllowFlight()) return;
 
         // Disable fly
         player.setFlying(false);

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -3,4 +3,4 @@ version: ${project.version}
 main: world.bentobox.islandfly.IslandFlyAddon
 authors: [DarkRails]
 description: Allow players to fly on their island
-softdepend: AcidIsland, BSkyBlock
+softdepend: AcidIsland, BSkyBlock, CaveBlock, SkyGrid

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1,8 +1,9 @@
 islandfly:
-  fly-outside-alert: "You are outside your island so fly mode will be disabled in [number] seconds."
-  disable-fly: "Your fly mode has been disabled."
-  enable-fly: "Your fly mode has been enabled."
-  cancel-disable: "You are back, huh! Fly fuel successfully refilled!"
+  fly-outside-alert: "&cYou are outside your island so fly mode will be disabled in &e[number]&c seconds."
+  disable-fly: "&cYour fly mode has been disabled."
+  enable-fly: "&aYour fly mode has been enabled."
+  cancel-disable: "&aYou are back, huh! Fly fuel successfully refilled!"
+  wrong-world: "&cYou are not in the right gamemode world"
   command:
     description: "allows you to fly on your island"
-    only-on-island: "You can only fly on your island."
+    only-on-island: "&cYou can only fly on your island."

--- a/src/main/resources/locales/fr-FR.yml
+++ b/src/main/resources/locales/fr-FR.yml
@@ -1,8 +1,9 @@
 islandfly:
-  fly-outside-alert: "Vous êtes hors de votre île, vous ne pourrez plus voler dans [number] secondes."
-  disable-fly: "Vous ne pouvez plus voler."
-  enable-fly: "Vous pouvez désormais voler."
-  cancel-disable: "Vous êtes de retour sur votre île ! Vous pouvez continuer à voler."
+  fly-outside-alert: "&cVous êtes hors de votre île, vous ne pourrez plus voler dans &e[number]&c secondes."
+  disable-fly: "&cVous ne pouvez plus voler."
+  enable-fly: "&aVous pouvez désormais voler."
+  cancel-disable: "&aVous êtes de retour sur votre île ! Vous pouvez continuer à voler."
+  wrong-world: "&cVous n'êtes pas dans le bon monde de mode de jeu."
   command:
     description: "vous permet de voler sur votre île"
-    only-on-island: "Vous pouvez uniquement voler sur votre île."
+    only-on-island: "&cVous pouvez uniquement voler sur votre île."


### PR DESCRIPTION
- Updates README.md
- Hooks into all gamemodes and not just hardcoded BSB and Acid
- Fixes and now prevents execution of /is fly in acid or so
- Now supports per gamemode permissions
**Important:** 
Permission is changed from **gamemode.fly** to **gamemode.island.fly** to fit as all other island commands (same goes for bypass permission)
- Adds wrong-world message and color-codes to locales
- Register listeners after the hook to gamemode was successful