### PR TITLE
Fixes bugs and implements features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.7.1</build.version>
+        <build.version>1.7.2</build.version>
         <build.number>-LOCAL</build.number>
     </properties>
 

--- a/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
+++ b/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
@@ -44,7 +44,6 @@ public class FlyToggleCommand extends CompositeCommand {
         if (island == null) return false;
 
         // Gets the island at User's location
-        // If, statement above did return true, there is no need to check #isPresent
 
         // Enable fly if island is a spawn and user has permission for it
         if (island.isSpawn()) {

--- a/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
+++ b/src/main/java/world/bentobox/islandfly/FlyToggleCommand.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 
 
@@ -38,10 +39,26 @@ public class FlyToggleCommand extends CompositeCommand {
             return false;
         }
 
-        if (!user.hasPermission(this.getPermissionPrefix() + "island.flybypass") && !getIslands().userIsOnIsland(user.getWorld(), user)) {
-            user.sendMessage("islandfly.command.only-on-island");
+        Island island = getIslands().getIslandAt(user.getLocation()).orElse(null);
+
+        if (island == null) return false;
+
+        // Gets the island at User's location
+        // If, statement above did return true, there is no need to check #isPresent
+
+        // Enable fly if island is a spawn and user has permission for it
+        if (island.isSpawn()) {
+            if (user.hasPermission(this.getPermissionPrefix() + "island.flyspawn"))
+                return true;
+        }
+
+        if (!island.isAllowed(user, IslandFlyAddon.ISLAND_FLY_PROTECTION) && !user.hasPermission(this.getPermissionPrefix() + "island.flybypass")) {
+
+            user.sendMessage("islandfly.command.not-allowed-fly");
             return false;
         }
+
+
         return true;
     }
 

--- a/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
+++ b/src/main/java/world/bentobox/islandfly/IslandFlyAddon.java
@@ -1,9 +1,13 @@
 package world.bentobox.islandfly;
 
+import org.bukkit.Material;
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.configuration.Config;
+import world.bentobox.bentobox.api.flags.Flag;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.islandfly.config.Settings;
 import world.bentobox.islandfly.listeners.FlyDeathListener;
+import world.bentobox.islandfly.listeners.FlyFlagListener;
 import world.bentobox.islandfly.listeners.FlyListener;
 import world.bentobox.islandfly.listeners.FlyLogoutListener;
 
@@ -16,6 +20,17 @@ public class IslandFlyAddon extends Addon {
      * Settings object for IslandFlyAddon
      */
     private Settings settings;
+
+    /**
+     * A flag to allow or disallow flight on island
+     * based on player's rank
+     */
+    public static final Flag ISLAND_FLY_PROTECTION =
+            new Flag.Builder("ISLAND_FLY_PROTECTION", Material.ELYTRA)
+                    .type(Flag.Type.PROTECTION)
+                    .mode(Flag.Mode.ADVANCED)
+                    .defaultRank(RanksManager.MEMBER_RANK)
+                    .defaultSetting(true).build();
 
     /**
      * Boolean that indicate if addon is hooked into any gamemode.
@@ -68,6 +83,8 @@ public class IslandFlyAddon extends Addon {
                         new FlyToggleCommand(playerCommand);
                         hooked = true;
                     });
+
+                ISLAND_FLY_PROTECTION.addGameModeAddon(gameModeAddon);
             }
         });
 
@@ -77,6 +94,10 @@ public class IslandFlyAddon extends Addon {
             registerListener(new FlyListener(this));
             registerListener(new FlyDeathListener(this));
             registerListener(new FlyLogoutListener(this));
+            registerListener(new FlyFlagListener(this));
+
+            // Register a flag
+            registerFlag(ISLAND_FLY_PROTECTION);
         }
     }
 

--- a/src/main/java/world/bentobox/islandfly/listeners/FlyFlagListener.java
+++ b/src/main/java/world/bentobox/islandfly/listeners/FlyFlagListener.java
@@ -1,0 +1,85 @@
+package world.bentobox.islandfly.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.events.flags.FlagProtectionChangeEvent;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.islandfly.IslandFlyAddon;
+
+public class FlyFlagListener implements Listener {
+
+    private BentoBox plugin;
+    private IslandFlyAddon addon;
+
+    public FlyFlagListener(IslandFlyAddon addon) {
+        this.plugin = addon.getPlugin();
+        this.addon = addon;
+    }
+
+    @EventHandler
+    public void onFlagChange(FlagProtectionChangeEvent e) {
+
+        if (!e.getEditedFlag().equals(IslandFlyAddon.ISLAND_FLY_PROTECTION))
+            return;
+
+        Island island = e.getIsland();
+
+        // Stream through all of the flying and not allowed users at
+        // the moment and warn them that their fly is about to turn off
+        e.getIsland().getPlayersOnIsland().parallelStream()
+                .filter(Player::isFlying)
+                .filter(p -> !(island.isAllowed(User.getInstance(p), IslandFlyAddon.ISLAND_FLY_PROTECTION) || p.isOp()))
+                .forEach(p -> {
+
+                    startDisabling(p, island);
+                });
+    }
+
+    public void startDisabling(Player p, Island island) {
+
+        int flyTimeout = this.addon.getSettings().getFlyTimeout();
+        User user = User.getInstance(p);
+
+
+        // Alert player fly will be disabled
+        user.sendMessage("islandfly.fly-turning-off-alert", TextVariables.NUMBER, String.valueOf(flyTimeout));
+
+        // If timeout is 0 or less disable fly immediately
+        if (flyTimeout <= 0) {
+
+            p.setFlying(false);
+            p.setAllowFlight(false);
+            user.sendMessage("islandfly.disable-fly");
+
+            return;
+        }
+
+        // Else disable fly with a delay
+        addon.getServer().getScheduler().runTaskLater(this.addon.getPlugin(), () -> {
+
+            // Verify that player is still online
+            if (!user.isOnline()) return;
+
+            // Check if user was reallowed to fly in the meantime
+            if (!island.isAllowed(user,IslandFlyAddon.ISLAND_FLY_PROTECTION)) {
+
+                // Silent cancel fly if player changed island in the meantime
+                // It will be the job of Enter/Exit island event to turn fly off if required
+                if (!island.onIsland(p.getLocation()))
+                    return;
+
+                p.setFlying(false);
+                p.setAllowFlight(false);
+                user.sendMessage("islandfly.disable-fly");
+            }
+            else {
+                user.sendMessage("islandfly.reallowed-fly");
+            }
+
+        }, 20L* flyTimeout);
+    }
+}

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -11,6 +11,9 @@ description: Allow players to fly on their island
 
 
 permissions:
+  acidisland.island.flyspawn:
+    description: Allows to use fly on spawn
+    default: op
   acidisland.island.fly:
     description: Allows access to fly command.
     default: true
@@ -18,6 +21,9 @@ permissions:
     description: Allows to keep fly mode on player death.
     default: op
 
+  bskyblock.island.flyspawn:
+    description: Allows to use fly on spawn
+    default: op
   bskyblock.island.fly:
     description: Allows access to fly command.
     default: true
@@ -25,6 +31,9 @@ permissions:
     description: Allows to keep fly mode on player death.
     default: op
 
+  caveblock.island.flyspawn:
+    description: Allows to use fly on spawn
+    default: op
   caveblock.island.fly:
     description: Allows access to fly command.
     default: true
@@ -32,6 +41,9 @@ permissions:
     description: Allows to keep fly mode on player death.
     default: op
 
+  skygrid.island.flyspawn:
+    description: Allows to use fly on spawn
+    default: op
   skygrid.island.fly:
     description: Allows access to fly command.
     default: true

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1,9 +1,17 @@
 islandfly:
   fly-outside-alert: "&cYou are outside your island so fly mode will be disabled in &e[number]&c seconds."
+  fly-turning-off-alert: "&cYou are not permitted to fly here anymore. Turning fly off in &e[number]&c seconds."
   disable-fly: "&cYour fly mode has been disabled."
+  reallowed-fly: "&aYour fly has been reallowed"
   enable-fly: "&aYour fly mode has been enabled."
   cancel-disable: "&aYou are back, huh! Fly fuel successfully refilled!"
   wrong-world: "&cYou are not in the right gamemode world"
   command:
     description: "allows you to fly on your island"
-    only-on-island: "&cYou can only fly on your island."
+    not-allowed-fly: "&cYou are not allowed to fly on this island"
+
+protection:
+  flags:
+    ISLAND_FLY_PROTECTION:
+      description: "&aToggle who can fly on your island"
+      name: "&aFly prevention"


### PR DESCRIPTION
- Implements flag in /is settings and a listener for island fly allowment (#5 )
Players can now change permission for others to fly on their island. If there are players already flying at the moment of change, they will get a warning that the permission has changed and will have enough time to fly down. The flight of a player is not anymore limited to only his own island.
- Adds a spawn fly permission  for spawn island (#2 )
- Fixes a bug where a disabling-warning message for fly was being sent on exitEvent even if player wasn't flying
- Updates version in pom to 1.7.2 (But it's up to devs to decide)
